### PR TITLE
Fix uncaught error when input chinese in text element

### DIFF
--- a/components/useSaveSnapshot.ts
+++ b/components/useSaveSnapshot.ts
@@ -23,12 +23,9 @@ export function useSaveSnapshot(store: TLStore, state: State) {
     const { document } = getSnapshot(store);
     const json = JSON.stringify(document, null, 2);
 
-    // send the snapshot as a data URL
-    const dataURL = "data:text/plain;base64," + btoa(json);
-
     // store the snapshot on disk via the vite plugin
     if (import.meta.hot) {
-      import.meta.hot.send("tldraw:store-file", { path: state.doc, content: dataURL });
+      import.meta.hot.send("tldraw:store-file", { path: state.doc, content: json });
     }
 
     // update the slide content to include the doc prop

--- a/components/useSaveSnapshot.ts
+++ b/components/useSaveSnapshot.ts
@@ -25,7 +25,7 @@ export function useSaveSnapshot(store: TLStore, state: State) {
 
     // store the snapshot on disk via the vite plugin
     if (import.meta.hot) {
-      import.meta.hot.send("tldraw:store-file", { path: state.doc, content: json });
+      import.meta.hot.send("tldraw:store-file", { path: state.doc, content: json, type: 'json' });
     }
 
     // update the slide content to include the doc prop

--- a/components/useStore.ts
+++ b/components/useStore.ts
@@ -21,6 +21,7 @@ const assets: TLAssetStore = {
       import.meta.hot.send("tldraw:store-file", {
         path: imagePath,
         content: encodedFile,
+	type: 'file',
       });
 
       // wait for the file to be stored

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,9 +23,8 @@ export default defineConfig({
           const docPath = cwd() + '/public/' + decodeURIComponent(data.path);
           const folderPath = dirname(docPath);
           try {
-            // use fetch to convert the dataURL to a blob
-            const res = await fetch(data.content);
-            const content = await res.blob();
+	    // convert json data to a blob
+	    const content = new Blob([data.content], { type: 'application/json;charset=utf-8' });
             // write the blob to the file system
             await mkdir(folderPath, { recursive: true });
             await writeFile(docPath, content.stream());

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import { cwd } from "node:process";
 type StoreFileData = {
   path: string;
   content: string;
+  type: 'file' | 'json';
 }
 
 export default defineConfig({
@@ -23,8 +24,15 @@ export default defineConfig({
           const docPath = cwd() + '/public/' + decodeURIComponent(data.path);
           const folderPath = dirname(docPath);
           try {
-	    // convert json data to a blob
-	    const content = new Blob([data.content], { type: 'application/json;charset=utf-8' });
+	    let content: Blob;
+	    if (data.type === 'json) {
+	      // convert json data to a blob
+	      content = new Blob([data.content], { type: 'application/json;charset=utf-8' });
+	    } else {
+	      // use fetch to convert the dataURL to a blob
+	      const res = await fetch(data.content);
+	      content = await res.blob();
+	    }
             // write the blob to the file system
             await mkdir(folderPath, { recursive: true });
             await writeFile(docPath, content.stream());


### PR DESCRIPTION
When input Chinese in a text element:

<img width="253" alt="WeChatWorkScreenshot_4780b5b0-eecf-46ed-9a39-ba57280a27c9" src="https://github.com/user-attachments/assets/5190a5cb-12fb-4161-8ba4-0338bbc84cab" />

Data will be store failed, and there will appear Uncaught error in console panel:

<img width="1420" alt="image" src="https://github.com/user-attachments/assets/d5ea09ca-b515-498f-b143-425001a6688c" />

Because `btoa` do not support Latin1 characters.
